### PR TITLE
only send messages to who need

### DIFF
--- a/cms/utils/send_attention.py
+++ b/cms/utils/send_attention.py
@@ -90,8 +90,8 @@ def attention(receiver, maintainer, cve_info):
 
 def receivers_statistics():
     """take turns sending messages"""
-    receivers = list(set(Vulnerability.objects.all().values_list('email', flat=True)))
+    receivers = list(set(Vulnerability.objects.filter(status=1).values_list('email', flat=True)))
     for receiver in receivers:
         maintainer = Vulnerability.objects.filter(email=receiver).values()[0].get('maintainer')
-        cve_info = list(Vulnerability.objects.filter(email=receiver))
+        cve_info = list(Vulnerability.objects.filter(email=receiver, status=1))
         attention(receiver, maintainer, cve_info)


### PR DESCRIPTION
限制获取全部收件人的范围为包含未处理的CVE，限制责任人收到的均为未处理的CVE